### PR TITLE
rebuild(gpkg/libsndfile): link with libflac 1.5.0

### DIFF
--- a/gpkg/libsndfile/build.sh
+++ b/gpkg/libsndfile/build.sh
@@ -3,6 +3,7 @@ TERMUX_PKG_DESCRIPTION="Library for reading/writing audio files"
 TERMUX_PKG_LICENSE="LGPL-2.1"
 TERMUX_PKG_MAINTAINER="@termux-pacman"
 TERMUX_PKG_VERSION="1.2.2"
+TERMUX_PKG_REVISION=1
 TERMUX_PKG_SRCURL=https://github.com/libsndfile/libsndfile/archive/refs/tags/${TERMUX_PKG_VERSION}.tar.gz
 TERMUX_PKG_SHA256=ffe12ef8add3eaca876f04087734e6e8e029350082f3251f565fa9da55b52121
 TERMUX_PKG_DEPENDS="libflac-glibc, libogg-glibc, libopus-glibc, libvorbis-glibc, libmpg123-glibc, libmp3lame-glibc"


### PR DESCRIPTION
This fixes the following runtime error.
pactl: error while loading shared libraries: libFLAC.so.12: cannot open shared object file: No such file or directory

* Fixes #346 